### PR TITLE
35 task   add servicetype content model and services pages

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -47,13 +47,13 @@ export default async function PageLayout({ children, params }: LayoutProps) {
   setRequestLocale(locale);
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html data-theme="light" lang={locale} suppressHydrationWarning>
       <head>
         <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#5bbad5" />
       </head>
       <body className="bg-base-100 text-base-content min-h-screen">
         <ThemeProvider
-          attribute="data-theme"
+          attribute="data-class"
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange>

--- a/src/app/[locale]/services/[slug]/page.tsx
+++ b/src/app/[locale]/services/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { CtfRichText } from '@/components/features/contentful';
+import PageTitle from '@/components/features/PageTitle';
 import { routing } from '@/i18n/routing';
 import { client, previewClient } from '@/lib/client';
 import { draftMode } from 'next/headers';
@@ -43,7 +44,7 @@ async function Servicepage({ params }: IServicePageProps) {
   console.log(page);
   return (
     <div className="container mx-auto p-12">
-      <h1 className="my-4 text-2xl tracking-tight">{page?.pageTitle}</h1>
+      <PageTitle titleText={page?.pageTitle} />
       <CtfRichText proseSize="prose-xl" json={page?.pageContent.json} />
     </div>
   );

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -1,3 +1,7 @@
+import { Link } from '@/i18n/routing';
+import { client, previewClient } from '@/lib/client';
+import { draftMode } from 'next/headers';
+
 const ServicesPage = async ({
   params,
 }: {
@@ -5,8 +9,24 @@ const ServicesPage = async ({
     locale: string;
   }>;
 }) => {
-  const locale = (await params).locale;
-  return <div>{locale}</div>;
+  const { isEnabled: preview } = await draftMode();
+  const gqlClient = preview ? previewClient : client;
+  const { locale } = await params;
+  const data = await gqlClient.pageServiceCollection({ locale: locale });
+  const pageCollection = data.pageServiceCollection;
+  return (
+    <div className="container mx-auto h-screen p-12">
+      <h1 className="my-4 text-2xl tracking-tight">Services</h1>
+      {pageCollection?.items.map(page => (
+        <Link
+          key={page.slug}
+          href={`/services/${page.slug}`}
+          className="text-primary-500 my-4 block text-lg font-semibold">
+          {page.pageTitle}
+        </Link>
+      ))}
+    </div>
+  );
 };
 
 export default ServicesPage;

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -1,3 +1,4 @@
+import PageTitle from '@/components/features/PageTitle';
 import { Link } from '@/i18n/routing';
 import { client, previewClient } from '@/lib/client';
 import { draftMode } from 'next/headers';
@@ -16,7 +17,7 @@ const ServicesPage = async ({
   const pageCollection = data.pageServiceCollection;
   return (
     <div className="container mx-auto h-screen p-12">
-      <h1 className="my-4 text-2xl tracking-tight">Services</h1>
+      <PageTitle titleText="Services" />
       {pageCollection?.items.map(page => (
         <Link
           key={page.slug}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,17 @@
 
 @plugin "daisyui";
 @plugin "@tailwindcss/typography";
-@plugin "daisyui";
+@plugin "daisyui" {
+  themes:
+    light --default,
+    dark --prefersdark;
+  root: ':root';
+
+  logs: true;
+}
+
+@theme {
+}
 
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,

--- a/src/components/features/PageTitle.tsx
+++ b/src/components/features/PageTitle.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import React from 'react';
+
+const PageTitle = ({ titleText }: { titleText: string }) => {
+  return (
+    <motion.h1
+      initial={{ opacity: 0, y: -20, scale: 0.7 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.6, delay: 0.2 }}
+      className="mb-12 text-center text-3xl font-bold tracking-tight md:mb-24 md:text-5xl">
+      {titleText}
+    </motion.h1>
+  );
+};
+
+export default PageTitle;

--- a/src/components/features/experience/ExperienceTimeline.tsx
+++ b/src/components/features/experience/ExperienceTimeline.tsx
@@ -1,7 +1,6 @@
-'use client';
-import { motion } from 'framer-motion';
 import type { PageExperience } from '@/lib/__generated/sdk';
 import TimelineItem from '@/components/features/experience/TimelineItem';
+import PageTitle from '@/components/features/PageTitle';
 
 interface IExperienceTimelineProps {
   experiences: PageExperience[];
@@ -9,13 +8,7 @@ interface IExperienceTimelineProps {
 
 const ExperienceTimeline = ({ experiences }: IExperienceTimelineProps) => (
   <div className="px-4 py-8 md:py-16">
-    <motion.h1
-      initial={{ opacity: 0, y: -20, scale: 0.7 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      transition={{ duration: 0.6, delay: 0.2 }}
-      className="mb-12 text-center text-3xl font-bold tracking-tight md:mb-24 md:text-5xl">
-      Professional Experience
-    </motion.h1>
+    <PageTitle titleText="Professional Experience" />
     <div className="relative mx-auto">
       <div className="bg-base-300/20 absolute left-1/2 hidden h-full w-px -translate-x-1/2 transform md:block" />
       {experiences.map((experience, index) => (


### PR DESCRIPTION
### **Add ServiceType Content Model and Services Pages**

#### **Description**
This PR introduces the `ServiceType` content model and implements functionality for services pages. The changes include internationalized content handling, GraphQL integration, and static page generation for improved performance and scalability.

---

#### **Changes Included**
1. **Contentful Content Model**  
   - Created `ServiceType` content model with necessary fields.  
   - Added a single internationalized entry for testing.

2. **GraphQL Integration**  
   - Added GraphQL queries and fragments for `ServiceType`.  
   - Generated queries and types using `graphql-codegen` and updated the SDK.

3. **Next.js Pages**  
   - Implemented `services/page.tsx` for listing all services.  
   - Implemented dynamic `services/[slug]/page.tsx` for individual service details.

4. **Static Site Generation**  
   - Configured `generateStaticParams` to dynamically generate routes, slugs, and locales.

5. **Integration**  
   - Wired up pages with the SDK and ensured proper data fetching and display.  
   - Tested internationalized routing and static generation.

---

#### **Testing and Validation**
- Verified GraphQL queries and fragments.  
- Confirmed correct type generation and usage in the SDK.  
- Tested service listing and detail pages in all supported locales.  
- Validated static generation for dynamic routes and locales.

---

#### **Next Steps**
- Ensure deployment works as expected in production.  
- Monitor performance and address any issues with static generation or routing.
