### PR TITLE
Update issue templates to use GitHub Form's YAML syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,7 +16,6 @@ body:
       label: Summary
       description: Please provide us with a brief summary of the bug, a few words will do. Providing screenshots is encouraged
       placeholder: Brief summary of the bug
-      required: true
 
   - type: textarea
     id: environment
@@ -24,7 +23,6 @@ body:
       label: Environment
       description: Which browser/operating system did you encounter this bug in?
       placeholder: Browser/Operating System
-      required: true
 
   - type: textarea
     id: steps_to_reproduce
@@ -32,7 +30,6 @@ body:
       label: Steps to reproduce
       description: Please provide us the steps for how to reproduce this bug
       placeholder: Steps to reproduce the bug
-      required: true
 
   - type: textarea
     id: expected_results
@@ -40,7 +37,6 @@ body:
       label: Expected results
       description: What did you expect to experience?
       placeholder: Expected results
-      required: true
 
   - type: textarea
     id: actual_results
@@ -48,4 +44,3 @@ body:
       label: Actual results
       description: What did you experience instead of the above?
       placeholder: Actual results
-      required: true

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -15,4 +15,3 @@ body:
       label: Feedback
       description: Please provide us with your feedback on the template
       placeholder: Your feedback
-      required: true

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -17,7 +17,6 @@ body:
       label: The problem
       description: Start with describing the problem you want to solve
       placeholder: Describe the problem
-      required: true
 
   - type: textarea
     id: proposed_solution
@@ -25,7 +24,6 @@ body:
       label: The proposed solution
       description: Detail the solution you're proposing to the problem above
       placeholder: Describe the proposed solution
-      required: true
 
   - type: textarea
     id: breaking_changes
@@ -33,4 +31,3 @@ body:
       label: Breaking changes
       description: Are there any breaking changes with this proposal? If so, please detail them here
       placeholder: Describe any breaking changes
-      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -17,7 +17,6 @@ body:
       label: Problem Statement
       description: Describe the current situation and why it needs to be addressed
       placeholder: Problem statement
-      required: true
 
   - type: textarea
     id: proposed_solution
@@ -25,7 +24,6 @@ body:
       label: Proposed Solution
       description: Outline your proposed approach to solving the problem
       placeholder: Proposed solution
-      required: true
 
   - type: textarea
     id: acceptance_criteria
@@ -33,7 +31,6 @@ body:
       label: Acceptance Criteria
       description: List specific, measurable outcomes that define when this task is complete
       placeholder: Acceptance criteria
-      required: true
 
   - type: checkboxes
     id: task_size_estimation
@@ -49,7 +46,6 @@ body:
           value: large
         - label: Extra Large (8+ hours)
           value: extra_large
-      required: true
 
   - type: textarea
     id: dependencies
@@ -57,7 +53,6 @@ body:
       label: Dependencies
       description: List any dependencies or blockers
       placeholder: Dependencies
-      required: true
 
   - type: textarea
     id: breaking_changes
@@ -65,7 +60,6 @@ body:
       label: Breaking Changes
       description: Document any breaking changes this task might introduce
       placeholder: Breaking changes
-      required: true
 
   - type: textarea
     id: additional_notes
@@ -73,4 +67,3 @@ body:
       label: Additional Notes
       description: Any other relevant information
       placeholder: Additional notes
-      required: true


### PR DESCRIPTION
Fixes #37

Update issue templates to use GitHub Form's YAML syntax.

* **Bug Report Template**: Remove the `required` property from the `attributes` section for `summary`, `environment`, `steps_to_reproduce`, `expected_results`, and `actual_results`.
* **Feedback Template**: Remove the `required` property from the `attributes` section for `feedback`.
* **Proposal Template**: Remove the `required` property from the `attributes` section for `the_problem`, `proposed_solution`, and `breaking_changes`.
* **Task Template**: Remove the `required` property from the `attributes` section for `problem_statement`, `proposed_solution`, `acceptance_criteria`, `task_size_estimation`, `dependencies`, `breaking_changes`, and `additional_notes`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patgpt/my-contentful-portfolio/pull/40?shareId=52846765-c7f6-4ffc-bee7-ba01e7e17846).