### PR TITLE
Refactor pages to use PageParams type

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -6,8 +6,9 @@ import { Container } from '@/components/shared/container';
 
 import { client, previewClient } from '@/lib/client';
 import { getTranslations } from 'next-intl/server';
+import type { PageParams } from '@/types/types';
 
-async function BlogListPage({ params }: { params: Promise<{ locale: string }> }) {
+async function BlogListPage({ params }: PageParams) {
   const locale = (await params).locale;
   const { isEnabled: preview } = await draftMode();
   const gqlClient = preview ? previewClient : client;

--- a/src/app/[locale]/experience/page.tsx
+++ b/src/app/[locale]/experience/page.tsx
@@ -3,15 +3,9 @@ import { draftMode } from 'next/headers';
 import { client, previewClient } from '@/lib/client';
 import ExperienceTimeline from '@/components/features/experience/ExperienceTimeline';
 import type { PageExperience } from '@/lib/__generated/sdk';
+import type { PageParams } from '@/types/types';
 
-interface ExperiencePageProps {
-  params: Promise<{
-    locale: string;
-    slug: string;
-  }>;
-}
-
-async function ExperiencePage(props: ExperiencePageProps) {
+async function ExperiencePage(props: PageParams) {
   const params = await props.params;
 
   const { locale } = params;
@@ -26,11 +20,9 @@ async function ExperiencePage(props: ExperiencePageProps) {
   const pages = pageExperienceCollection.pageExperienceCollection?.items as PageExperience[];
 
   return (
-
-      <div className="relative container mx-auto px-4">
-        <ExperienceTimeline experiences={pages} />
-      </div>
-    
+    <div className="relative container mx-auto px-4">
+      <ExperienceTimeline experiences={pages} />
+    </div>
   );
 }
 

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -1,15 +1,10 @@
 import PageTitle from '@/components/features/PageTitle';
 import { Link } from '@/i18n/routing';
 import { client, previewClient } from '@/lib/client';
+import type { PageParams } from '@/types/types';
 import { draftMode } from 'next/headers';
 
-const ServicesPage = async ({
-  params,
-}: {
-  params: Promise<{
-    locale: string;
-  }>;
-}) => {
+const ServicesPage = async ({ params }: PageParams) => {
   const { isEnabled: preview } = await draftMode();
   const gqlClient = preview ? previewClient : client;
   const { locale } = await params;


### PR DESCRIPTION
Update BlogListPage, ExperiencePage, and ServicesPage to utilize the PageParams type for improved type safety and consistency.